### PR TITLE
Update first mention of 'render json:'

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ serializing resources in a Rails-y way.
 
 What does that mean? At a basic level, it means that if we have a `Post` model,
 then we can also have a `PostSerializer` serializer, and by default, Rails will
-use our serializer if we simply call `render json: post` in a controller.
+use our serializer if we simply call `render json: @post` in a controller.
 
 How is that different than when we created our own serializer by
 hand and used it in the controller? Remember:


### PR DESCRIPTION
The first time `render json:` with a model name is mentioned, it omits the `@` before `post`.

Calling `render json: post` will not get the controller to properly render the json. All subsequent references to this method in the curriculum use `@post` to correctly reference the instance variable.

I hope this suggestion enhances consistency and decreases confusion! Please let me know if there was another intention for writing the first reference without the `@`.